### PR TITLE
Bug Fix: Index out of bounds error when parsing visit details

### DIFF
--- a/src/main/java/bookbob/entity/Patient.java
+++ b/src/main/java/bookbob/entity/Patient.java
@@ -22,13 +22,12 @@ public class Patient {
     }
 
     // constructor used in retrieving data
-    public Patient(String name, String nric, String phoneNumber, String dateOfBirth, String homeAddress, List<Visit> visits) {
+    public Patient(String name, String nric, String phoneNumber, String dateOfBirth, String homeAddress) {
         this.name = name;
         this.nric = nric;
         this.dateOfBirth = dateOfBirth;
         this.phoneNumber = phoneNumber;
         this.homeAddress = homeAddress;
-        this.visits = visits;
     }
 
     // getters and setters
@@ -84,6 +83,6 @@ public class Patient {
     public String toString() {
         return "Name: " + getName() + ", NRIC: " + getNric() +
                 ", Phone: " + getPhoneNumber() +  ", Address: " + getHomeAddress() +
-                ", DOB: " + getDateOfBirth() + getVisit();
+                ", DOB: " + getDateOfBirth();
     }
 }

--- a/src/main/java/bookbob/entity/Patient.java
+++ b/src/main/java/bookbob/entity/Patient.java
@@ -22,12 +22,13 @@ public class Patient {
     }
 
     // constructor used in retrieving data
-    public Patient(String name, String nric, String phoneNumber, String dateOfBirth, String homeAddress) {
+    public Patient(String name, String nric, String phoneNumber, String dateOfBirth, String homeAddress, List<Visit> visits) {
         this.name = name;
         this.nric = nric;
         this.dateOfBirth = dateOfBirth;
         this.phoneNumber = phoneNumber;
         this.homeAddress = homeAddress;
+        this.visits = visits;
     }
 
     // getters and setters
@@ -83,6 +84,6 @@ public class Patient {
     public String toString() {
         return "Name: " + getName() + ", NRIC: " + getNric() +
                 ", Phone: " + getPhoneNumber() +  ", Address: " + getHomeAddress() +
-                ", DOB: " + getDateOfBirth();
+                ", DOB: " + getDateOfBirth() + getVisit();
     }
 }

--- a/src/main/java/bookbob/functions/FileHandler.java
+++ b/src/main/java/bookbob/functions/FileHandler.java
@@ -201,15 +201,20 @@ public class FileHandler {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
         LocalDateTime visitDateTime = LocalDateTime.parse(dateTimeString, formatter);
 
-        // Parse diagnosis
-        String diagnosisString = components[1].trim();
         ArrayList<String> diagnosisList = new ArrayList<>();
-        diagnosisList.addAll(Arrays.asList(diagnosisString.split(",\\s*")));
-
-        // Parse medications
-        String medicationsString = components[2].trim();
         ArrayList<String> medicationsList = new ArrayList<>();
-        medicationsList.addAll(Arrays.asList(medicationsString.split(",\\s*")));
+
+        // Check if diagnosis and medication are included in visit details
+        if(components.length > 1) {
+            // Parse diagnosis
+            String diagnosisString = components[1].trim();
+            diagnosisList.addAll(Arrays.asList(diagnosisString.split(",\\s*")));
+
+            // Parse medications
+            String medicationsString = components[2].trim();
+            medicationsList.addAll(Arrays.asList(medicationsString.split(",\\s*")));
+        }
+
         return new Visit(visitDateTime, diagnosisList, medicationsList);
     }
 }


### PR DESCRIPTION
Error happened due to empty diagnosis and medication strings and the parsed string array was not as long as the code assumed